### PR TITLE
feat: update GitHub Action to support Ibis Next

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: Ibis eBook Generation
+name: Ibis Next eBook Generation
 on:
   push:
     branches:
@@ -7,14 +7,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
-      with:
-        fetch-depth: '0'
-    - name: Build Ibis Export Files
-      uses: bobbyiliev/ibis-build-action@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        IBIS_PATH: './ebook/en'
-        IBIS_BRANCH: 'main'
-        EMAIL: 'bobby@bobbyiliev.com'
-        COMMIT_MESSAGE: 'Updated Ibis Exorted Files'
+      - uses: actions/checkout@main
+        with:
+          fetch-depth: "0"
+      - name: Build Ibis Next Export Files
+        uses: bobbyiliev/ibis-build-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IBIS_PATH: "./ebook/en"
+          IBIS_BRANCH: "main"
+          EMAIL: "bobby@bobbyiliev.com"
+          COMMIT_MESSAGE: "Updated Ibis Next Exported Files"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
-FROM composer:2.1.9
+FROM php:8.4-cli-alpine
+
 LABEL "repository"="https://github.com/bobbyiliev/ibis-build-action"
 LABEL "homepage"="https://github.com/bobbyiliev/ibis-build-action"
 LABEL "maintainer"="Bobby Iliev"
 
-# Install PHP 7 and all required modules
-RUN apk add php7 php7-phar php7-iconv php7-mbstring php7-json php7-openssl php7-gd
-# Install Ibis
-RUN php7 /usr/bin/composer global require themsaid/ibis
+ENV COMPOSER_HOME=/tmp
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Install PHP modules and Ibis Next
+RUN apk add --no-cache libpng-dev libjpeg-turbo-dev freetype-dev libzip-dev git \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install gd zip \
+    && composer global require hi-folks/ibis-next
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 A GitHub Action to automatically run ibis builds on merge to `main`.
 
-![Ibis GitHub Action](https://user-images.githubusercontent.com/21223421/139258477-107b1da3-6c02-4a81-a827-d58380a43252.png)
+![Ibis Next GitHub Action](https://user-images.githubusercontent.com/21223421/139258477-107b1da3-6c02-4a81-a827-d58380a43252.png)
 
 ---
 
-### Ibis
+### Ibis Next
 
-[Ibis](https://github.com/themsaid/ibis) is a PHP tool that lets you write eBooks in Markdown.
+[Ibis Next](https://github.com/Hi-Folks/ibis-next) is a PHP tool that lets you write eBooks in Markdown.
 
 ---
 
 ### Usage
 
-In order to automatically build your Ibis PDF files, create a directory called `.github/workflows/` and add a fill called `ibis.yml` with the following content:
+In order to automatically build your Ibis Next PDF files, create a directory called `.github/workflows/` and add a fill called `ibis.yml` with the following content:
 
 ```yaml
-name: Ibis eBook Generation
+name: Ibis Next eBook Generation
 on:
   push:
     branches:
@@ -27,42 +27,42 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
-      with:
-        fetch-depth: '0'
-    - name: Build Ibis Export Files
-      uses: bobbyiliev/ibis-build-action@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        IBIS_PATH: './'
-        IBIS_BRANCH: 'main'
-        EMAIL: 'bobby@bobbyiliev.com'
-        COMMIT_MESSAGE: 'Updated Ibis Exorted Files'
+      - uses: actions/checkout@main
+        with:
+          fetch-depth: "0"
+      - name: Build Ibis Next Export Files
+        uses: bobbyiliev/ibis-build-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IBIS_PATH: "./"
+          IBIS_BRANCH: "main"
+          EMAIL: "bobby@bobbyiliev.com"
+          COMMIT_MESSAGE: "Updated Ibis Next Exported Files"
 ```
 
 ## Environment Variables
 
-* `GITHUB_TOKEN`: Required for permission to tag the repo. You can leave it as it is.
-* `IBIS_PATH`: The path to the Ibis init folder. By default it is `./` but if you have a custom location, make sure to update it
-* `IBIS_BRANCH`: The Branch that the Ibis exported files will be commited and pushed to. Default is `main`.
-* `EMAIL`: The email address that the commit will be associated with.
-* `COMMIT_MESSAGE`: The commit message.
+- `GITHUB_TOKEN`: Required for permission to tag the repo. You can leave it as it is.
+- `IBIS_PATH`: The path to the Ibis init folder. By default it is `./` but if you have a custom location, make sure to update it
+- `IBIS_BRANCH`: The Branch that the Ibis exported files will be commited and pushed to. Default is `main`.
+- `EMAIL`: The email address that the commit will be associated with.
+- `COMMIT_MESSAGE`: The commit message.
 
 ## Workflow
 
-* Add this action to your repository
-* Commit some changes
-* Either push to `main` or open a PR
-* On push (or merge), the action will:
-    * Clone the repository
-    * Run the `ibis build` commands including the sample builds
-    * Stage and commit the new exported eBook files to the specified branch
-    * Pushes tag to GitHub
+- Add this action to your repository
+- Commit some changes
+- Either push to `main` or open a PR
+- On push (or merge), the action will:
+  - Clone the repository
+  - Run the `ibis-next pdf` commands including the sample builds
+  - Stage and commit the new exported eBook files to the specified branch
+  - Pushes tag to GitHub
 
 ## Ebook Projects using ibis-build-action
 
-* [Introduction to Docker](https://github.com/bobbyiliev/introduction-to-docker-ebook)
-* [Introduction to Git and GitHub](https://github.com/bobbyiliev/introduction-to-git-and-github-ebook)
-* [Introduction to Bash Scripting](https://github.com/bobbyiliev/introduction-to-bash-scripting)
-* [Introduction to SQL](https://github.com/bobbyiliev/introduction-to-sql)
-* [Laravel tips and tricks](https://github.com/bobbyiliev/laravel-tips-and-tricks-ebook)
+- [Introduction to Docker](https://github.com/bobbyiliev/introduction-to-docker-ebook)
+- [Introduction to Git and GitHub](https://github.com/bobbyiliev/introduction-to-git-and-github-ebook)
+- [Introduction to Bash Scripting](https://github.com/bobbyiliev/introduction-to-bash-scripting)
+- [Introduction to SQL](https://github.com/bobbyiliev/introduction-to-sql)
+- [Laravel tips and tricks](https://github.com/bobbyiliev/laravel-tips-and-tricks-ebook)

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,12 @@
-name: 'Ibis Builds'
-description: 'Automatically build new eBook PDF files using Ibis'
-author: 'Bobby Iliev'
+name: "Ibis Next Builds"
+description: "Automatically build new eBook PDF files using Ibis Next"
+author: "Bobby Iliev"
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
 outputs:
   build:
-    description: 'Ibis build completed'
+    description: "Ibis Next build completed"
 branding:
-  icon: 'git-merge'  
-  color: 'purple'
+  icon: "git-merge"
+  color: "purple"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,17 +9,17 @@ branch=${IBIS_BRANCH:-main}
 # Email id used while committing to the repo
 email=${EMAIL:-bobby@bobbyiliev.com}
 # The commit message
-commit_message=${COMMIT_MESSAGE:-Updated Ibis Exorted Files}
+commit_message=${COMMIT_MESSAGE:-Updated Ibis Next Exported Files}
 
 # build the PDF
 cd ${ibis_path}
-php7 /tmp/vendor/bin/ibis build
-php7 /tmp/vendor/bin/ibis build dark
-php7 /tmp/vendor/bin/ibis sample
-php7 /tmp/vendor/bin/ibis sample dark
+php /tmp/vendor/bin/ibis-next pdf
+php /tmp/vendor/bin/ibis-next pdf dark
+php /tmp/vendor/bin/ibis-next sample
+php /tmp/vendor/bin/ibis-next sample dark
 
 # commit the new files
-git config --global user.email 
+git config --global user.email "${email}"
 git fetch
 git checkout ${branch}
 git add export/


### PR DESCRIPTION
ummary
This PR updates the GitHub Action to support [Ibis Next](https://github.com/Hi-Folks/ibis-next), the actively maintained fork of Ibis.

Changes
Updated workflow steps to run ibis-next instead of ibis.
Fixed commit message typo (Exported instead of Exorted).
Ensured compatibility with the ./ebook/en/ path.
Changed all the files corresponding to running the actions.
This ensures continued eBook generation support for the project.

Screenshot
<img width="565" height="351" alt="image" src="https://github.com/user-attachments/assets/ac887a25-c7a6-462a-8684-dedd6f838d76" />

Working build